### PR TITLE
fix: cd no args working

### DIFF
--- a/src/buildins/cd/cd.c
+++ b/src/buildins/cd/cd.c
@@ -74,7 +74,7 @@ int	cd(t_app *app, t_cmd_info *cmd)
 	char	*abs_path;
 
 	if (!cmd->args[1])
-		return (0);
+		cmd->args[1] = NULL;
 	if (get_char_arr_len(cmd->args) > 2)
 		return (set_err(cmd, ERR_MANY_ARGS, "cd"), 1);
 	abs_path = get_abs_path(app, cmd->args[1]);

--- a/src/buildins/cd/cd_utils.c
+++ b/src/buildins/cd/cd_utils.c
@@ -17,8 +17,11 @@ int	folder_access(t_app *app, t_cmd_info *cmd, char *path, char *og_path)
 	struct stat	sb;
 	char		*subject;
 
-	subject = ft_strjoin("cd: ", og_path);
-	add_to_malloc_list(&app->malloc_list, subject);
+	if (og_path != NULL)
+	{
+		subject = ft_strjoin("cd: ", og_path);
+		add_to_malloc_list(&app->malloc_list, subject);
+	}
 	stat(path, &sb);
 	if (access(path, F_OK))
 		return (app->ret_val = 127, set_err(cmd, ERR_NO_FILE, subject));


### PR DESCRIPTION
Apparently I implemented 'cd ' without args and it was not working. So surely it feels fine that it got fixed, even though it was not mandatory