### PR TITLE
fix: signals in normal shell are represented in return value, shell d…

### DIFF
--- a/src/exe/exe_bin.c
+++ b/src/exe/exe_bin.c
@@ -63,7 +63,7 @@ int	call_execve(t_exe *exe, t_app *app, t_cmd_info *cmd)
 		exit(-1);
 	}
 	waitpid(pid, &status, 0);
-	if (WIFSIGNALED(status))
+	if (g_global_signal == ERR_SIGTER || g_global_signal == ERR_SIGINT)
 		app->ret_val = g_global_signal;
 	else
 		app->ret_val = WEXITSTATUS(status);

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -42,7 +42,7 @@ int	main(int argc, char **argv, char *envp[])
 		write(2, "Invalid arguments\n", 18);
 		return (-1);
 	}
-	welcome_screen(envp);
+	//welcome_screen(envp);
 	app = init_shell(envp);
 	if (app == NULL)
 		return (-1);

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -42,7 +42,7 @@ int	main(int argc, char **argv, char *envp[])
 		write(2, "Invalid arguments\n", 18);
 		return (-1);
 	}
-	//welcome_screen(envp);
+	welcome_screen(envp);
 	app = init_shell(envp);
 	if (app == NULL)
 		return (-1);

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -62,6 +62,13 @@ void	process_input(char *read_line, t_cmd_info *cmd, t_app *app)
 	free_hd_list(&app->hds);
 	free(read_line);
 }
+void	prompt_err(t_cmd_info *cmd, t_app *app, char *read_line)
+{
+	cmd->err_info.code = ERR_MALLOC;
+	exit_with_error(*cmd);
+	free_malloc_list(app);
+	free(read_line);
+}
 
 void	start_shell(t_app *app)
 {
@@ -72,15 +79,15 @@ void	start_shell(t_app *app)
 	{
 		cmd = NULL;
 		init_sa_shell(app);
+		disable_ctrl_c_echo(1);
 		if (set_prompt(&app->prompt, &app->malloc_list) == -1)
 		{
-			cmd->err_info.code = ERR_MALLOC;
-			exit_with_error(*cmd);
-			free_malloc_list(app);
-			free(read_line);
+			prompt_err(cmd, app, read_line);
 			break ;
 		}
 		read_line = readline(app->prompt);
+		if (g_global_signal == 130)
+			app->ret_val = g_global_signal;
 		if (read_line == NULL)
 		{
 			write(STDOUT_FILENO, "exit\n", 5);

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -62,6 +62,7 @@ void	process_input(char *read_line, t_cmd_info *cmd, t_app *app)
 	free_hd_list(&app->hds);
 	free(read_line);
 }
+
 void	prompt_err(t_cmd_info *cmd, t_app *app, char *read_line)
 {
 	cmd->err_info.code = ERR_MALLOC;

--- a/src/signals/signals.c
+++ b/src/signals/signals.c
@@ -23,6 +23,7 @@ void	handle_signal_shell(int sig)
 		rl_on_new_line();
 		rl_replace_line("", 0);
 		rl_redisplay();
+		g_global_signal = ERR_SIGINT;
 	}
 }
 


### PR DESCRIPTION
…oes no longer show C on SIGINT, if execution is signaled this shows in ret_val - nothing destroyed in the tester on the way

pls feel free to test 